### PR TITLE
Add combine_all_yearly_contributions query parameter to fetch and combine all yearly contributions, not only recent contributions

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ To hide specific ranks, you can pass a query parameter `&hide=` with comma-separ
 ```
 
 ### Including all contributions, not only recent contributions
-By default, the dard is generated from GitHub's GraphQL API `repositoriesContributedTo`, which only includes recent contributions. To include all contributions, add `&combine_all_yearly_contributions=true` query parameter, which will let the card be generated from GitHub's GraphQL API `contributionsCollection`, including all contributions.
+By default, the card is generated from GitHub's GraphQL API `repositoriesContributedTo`, which only includes recent contributions. To include all contributions, add `&combine_all_yearly_contributions=true` query parameter, which will let the card be generated from GitHub's GraphQL API `contributionsCollection`, including all contributions.
 
 ```md
 ![Taehyun's GitHub Repository Contribution stats](https://github-contributor-stats.vercel.app/api?username=HwangTaehyun&combine_all_yearly_contributions=true)

--- a/README.md
+++ b/README.md
@@ -35,6 +35,13 @@ To hide specific ranks, you can pass a query parameter `&hide=` with comma-separ
 ![Taehyun's GitHub Repository Contribution stats](https://github-contributor-stats.vercel.app/api?username=HwangTaehyun&hide=B,B%2B)
 ```
 
+### Including all contributions, not only recent contributions
+By default, the dard is generated from GitHub's GraphQL API `repositoriesContributedTo`, which only includes recent contributions. To include all contributions, add `&combine_all_yearly_contributions=true` query parameter, which will let the card be generated from GitHub's GraphQL API `contributionsCollection`, including all contributions.
+
+```md
+![Taehyun's GitHub Repository Contribution stats](https://github-contributor-stats.vercel.app/api?username=HwangTaehyun&combine_all_yearly_contributions=true)
+```
+
 ### Themes
 
 With inbuilt themes, you can customize the look of the card without doing any [manual customization](#customization).

--- a/api/main.ts
+++ b/api/main.ts
@@ -44,7 +44,6 @@ app.get('/api', async (req, res) => {
     const result = await (combine_all_yearly_contributions
       ? fetchAllContributorStats(username)
       : fetchContributorStats(username));
-    console.log(result)
     const name = result.name;
     const contributorStats = result.repositoriesContributedTo.nodes;
 

--- a/api/main.ts
+++ b/api/main.ts
@@ -7,6 +7,7 @@ import {
   renderError,
 } from '@/common/utils';
 import { fetchContributorStats } from '@/fetchContributorStats';
+import { fetchAllContributorStats } from '@/fetchAllContributorStats';
 import { isLocaleAvailable } from '@/translations';
 import express from 'express';
 
@@ -31,6 +32,7 @@ app.get('/api', async (req, res) => {
     theme,
     cache_seconds,
     locale,
+    combine_all_yearly_contributions,
   } = req.query;
   res.set('Content-Type', 'image/svg+xml');
 
@@ -39,7 +41,10 @@ app.get('/api', async (req, res) => {
   }
 
   try {
-    const result = await fetchContributorStats(username);
+    const result = await (combine_all_yearly_contributions
+      ? fetchAllContributorStats(username)
+      : fetchContributorStats(username));
+    console.log(result)
     const name = result.name;
     const contributorStats = result.repositoriesContributedTo.nodes;
 

--- a/src/fetchAllContributorStats.ts
+++ b/src/fetchAllContributorStats.ts
@@ -1,0 +1,104 @@
+import axios from 'axios';
+
+/**
+ * The Fetch All Contributor Stats Function.
+ *
+ * This function combines all the yearly `contributionsCollection` from the
+ * github graphql APIs.
+ *
+ * @param {String} username The target github username for contribution stats.
+ *
+ * @return {*}
+ */
+export async function fetchAllContributorStats(username) {
+  const {
+    data: {
+      data: {
+        user: {
+          id,
+          name,
+          contributionsCollection: { contributionYears },
+        },
+      },
+    },
+  } = await axios({
+    url: 'https://api.github.com/graphql',
+    method: 'POST',
+    headers: {
+      Authorization: `token ${process.env.GITHUB_PERSONAL_ACCESS_TOKEN}`,
+    },
+    validateStatus: (status) => status == 200,
+    data: {
+      query: `query {
+          user(login: "${username}") {
+            id
+            name
+            contributionsCollection {
+              contributionYears
+            }
+          }
+        }`,
+    },
+  });
+  return {
+    id,
+    name,
+    repositoriesContributedTo: {
+      nodes: Object.values(
+        Object.fromEntries(
+          (
+            await Promise.all(
+              (contributionYears as string[]).map((contributionYear) =>
+                axios({
+                  url: 'https://api.github.com/graphql',
+                  method: 'POST',
+                  headers: {
+                    Authorization: `token ${process.env.GITHUB_PERSONAL_ACCESS_TOKEN}`,
+                  },
+                  validateStatus: (status) => status == 200,
+                  data: {
+                    query: `query {
+                      user(login: ${JSON.stringify(username)}) {
+                        contributionsCollection(from: "${contributionYear}-01-01T00:00:00Z") {
+                          commitContributionsByRepository(maxRepositories: 100) {
+                            repository {
+                              owner {
+                                id
+                                avatarUrl
+                              }
+                              isInOrganization
+                              url
+                              homepageUrl
+                              name
+                              nameWithOwner
+                              stargazerCount
+                              openGraphImageUrl
+                            }
+                          }
+                        }
+                      }
+                    }`,
+                  },
+                }),
+              ),
+            )
+          ).flatMap(
+            ({
+              data: {
+                data: {
+                  user: {
+                    contributionsCollection: { commitContributionsByRepository },
+                  },
+                },
+              },
+            }) =>
+              commitContributionsByRepository.map(({ repository }) => [
+                repository.nameWithOwner,
+                repository,
+              ]),
+          ),
+        ),
+      ),
+    },
+  };
+}

--- a/src/fetchContributorStats.ts
+++ b/src/fetchContributorStats.ts
@@ -13,7 +13,8 @@ import axios from 'axios';
 /**
  * The Fetch Contributor Stats Function.
  *
- * This function holds the request for the github graphql APIs.
+ * This function holds the request for the github graphql APIs, which includes
+ * recent commit contributions.
  *
  * @param {String} username The target github username for contribution stats.
  *


### PR DESCRIPTION
Rendering result on my local server:

<details>
  <summary>http://localhost:9999/api?username=Atry</summary>
  <p>
    <img src="https://user-images.githubusercontent.com/601530/217112644-8d71b82e-58d9-4b86-87df-3eabc07fb2ca.svg"/>
  </p>
</details>
<details>
  <summary>http://localhost:9999/api?username=Atry&combine_all_yearly_contributions=true</summary>
  <p>
    <img src="https://user-images.githubusercontent.com/601530/217112655-4f257f18-f10d-4b74-8f65-fd2f6c547690.svg"/>
  </p>
</details>



This PR fixes #6