### PR TITLE
Make cards more compact

### DIFF
--- a/src/cards/stats-card.ts
+++ b/src/cards/stats-card.ts
@@ -211,7 +211,7 @@ export const renderContributorStatsCard = async (
     progress: true,
   });
 
-  const width = 495;
+  const width = 450;
 
   const card = new Card({
     customTitle: custom_title,

--- a/src/common/Card.ts
+++ b/src/common/Card.ts
@@ -54,8 +54,8 @@ export class Card {
 
     this.css = '';
 
-    this.paddingX = 25;
-    this.paddingY = 35;
+    this.paddingX = 15;
+    this.paddingY = 25;
     this.titlePrefixIcon = titlePrefixIcon;
     this.animations = true;
     this.a11yTitle = '';
@@ -212,17 +212,17 @@ export class Card {
       >
         ${flexLayout({
           items: [githubIcon, repoTitleText],
-          gap: 30,
+          gap: 20,
           direction: 'row',
         }).join('')}
       </g>
       <g
         data-testid="card-title"
-        transform="translate(${this.paddingX + 235}, ${this.paddingY + 30})"
+        transform="translate(${this.paddingX + 190}, ${this.paddingY + 30})"
       >
         ${flexLayout({
           items: [!this.hideContributorRank && gitPRIcon, starIcon],
-          gap: 50,
+          gap: 30,
           direction: 'row',
         }).join('')}
       </g>

--- a/src/common/utils.ts
+++ b/src/common/utils.ts
@@ -12,13 +12,13 @@ import FileReader from 'filereader';
  */
 export const renderError = (message, secondaryMessage = '') => {
   return `
-    <svg width="495" height="120" viewBox="0 0 495 120" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <svg width="450" height="120" viewBox="0 0 450 120" fill="none" xmlns="http://www.w3.org/2000/svg">
     <style>
     .text { font: 600 16px 'Segoe UI', Ubuntu, Sans-Serif; fill: #2F80ED }
     .small { font: 600 12px 'Segoe UI', Ubuntu, Sans-Serif; fill: #252525 }
     .gray { fill: #858585 }
     </style>
-    <rect x="0.5" y="0.5" width="494" height="99%" rx="4.5" fill="#FFFEFE" stroke="#E4E2E2"/>
+    <rect x="0.5" y="0.5" width="449" height="99%" rx="4.5" fill="#FFFEFE" stroke="#E4E2E2"/>
     <text x="25" y="45" class="text">Something went wrong! file an issue at https://tiny.one/readme-stats</text>
     <text data-testid="message" x="25" y="55" class="text small">
       <tspan x="25" dy="18">${encodeHTML(message)}</tspan>


### PR DESCRIPTION
The exiting card has unnecessary spacing:

<img width="657" height="372" alt="image" src="https://github.com/user-attachments/assets/6b073224-b1b7-450b-8876-c2f0036d3b6c" />
